### PR TITLE
Fixes Gist ID Parsing for Read Error

### DIFF
--- a/src/pug.sh
+++ b/src/pug.sh
@@ -26,10 +26,8 @@ pug_install() {
     GIST_NAT=$(pacman -Qqen | gist -p -f "${PACMANFILE}" -d 'Pacman package list.')
     GIST_AUR=$(pacman -Qqem | gist -p -f "${AURFILE}" -d 'AUR package list.')
 
-    echo "GIST_NAT=${GIST_NAT}" | \
-        sed 's/https:\/\/gist.github.com\///g' > "${pkgdir}/etc/pug";
-    echo "GIST_AUR=${GIST_AUR}" | \
-        sed 's/https:\/\/gist.github.com\///g' >> "${pkgdir}/etc/pug";
+    echo "GIST_NAT=${GIST_NAT}" | sed 's#.*/##' > "${pkgdir}/etc/pug";
+    echo "GIST_AUR=${GIST_AUR}" | sed 's#.*/##' > "${pkgdir}/etc/pug";
 
     echo "    [ ${cyan}${GIST_NAT}${white} ]"
     echo "    [ ${cyan}${GIST_AUR}${white} ]"


### PR DESCRIPTION
Hey @Ventto, this PR fixes gist read operation by removing the Github user from the `/etc/pug` file. When the username is present the following error is thrown by the `gist` cli:

```
# gist -r <github-username>/<gist-id>

Error: Gist with id of <github-username>/<gist-id> does not exist.
```

But when ran without a username the command runs successfully. 
This behavior has made this pacman hook unusable for me in the last month, i would appreciate if you'd take a look :)